### PR TITLE
Remove second cert validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,16 +77,3 @@ resource "aws_acm_certificate" "cert-east" {
     create_before_destroy = true
   }
 }
-
-resource "aws_route53_record" "cert_validation_east" {
-  count = replace(
-    replace(data.aws_region.current.name, "us-east-1", "0"),
-    "/^[a-z].*[0-9]$/",
-    1,
-  )
-  name    = aws_acm_certificate.cert-east[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.cert-east[0].domain_validation_options[0].resource_record_type
-  zone_id = aws_route53_zone.this.zone_id
-  records = [aws_acm_certificate.cert-east[0].domain_validation_options[0].resource_record_value]
-  ttl     = 60
-}


### PR DESCRIPTION
Remove extra cert validation because same CNAME record is generated for both regions.