### PR TITLE
optional ACM certificate output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "zone_name_servers" {
 
 output "certificate_arn" {
   description = "ACM SSL Certificate ARN"
-  value       = aws_acm_certificate.this[0].arn
+  value       = var.create_certificate ? aws_acm_certificate.this[0].arn : ""
 }
 
 output "zone_id" {


### PR DESCRIPTION
Deployment will fail if `create_certificate = false`:

```
Error: Invalid index

  on .terraform/modules/main_hosted_zone/outputs.tf line 10, in output "certificate_arn":
  10:   value       = aws_acm_certificate.this[0].arn
    |----------------
    | aws_acm_certificate.this is empty tuple
```